### PR TITLE
Fix build by isolating test sources

### DIFF
--- a/Tests/Accessibility/AccessibilityAutomationTests.swift
+++ b/Tests/Accessibility/AccessibilityAutomationTests.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 import SwiftUI
 import XCTest
 
@@ -475,3 +476,4 @@ struct AccessibilityReport: Codable {
     let issuesBySeverity: [String: Int]
     let results: [AccessibilityAutomationTests.AccessibilityTestResult]
 }
+#endif

--- a/Tests/Accessibility/AccessibilityValidationService.swift
+++ b/Tests/Accessibility/AccessibilityValidationService.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 import Foundation
 import SwiftUI
 import UIKit
@@ -432,3 +433,4 @@ struct AccessibilityIssuesView: View {
         }
     }
 }
+#endif

--- a/Tests/Enterprise/Directory/DirectoryServiceTests.swift
+++ b/Tests/Enterprise/Directory/DirectoryServiceTests.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 import XCTest
 import Combine
 @testable import DiamondDeskERP
@@ -519,3 +520,4 @@ extension DirectoryError: LocalizedError {
         }
     }
 }
+#endif

--- a/Tests/Enterprise/Directory/DirectoryViewModelTests.swift
+++ b/Tests/Enterprise/Directory/DirectoryViewModelTests.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 import XCTest
 import Combine
 @testable import DiamondDeskERP
@@ -849,3 +850,4 @@ protocol DirectoryServiceProtocol {
     func exportEmployeesToCSV() async throws -> URL
     func exportVendorsToCSV() async throws -> URL
 }
+#endif

--- a/Tests/Enterprise/Financial/FinancialTests.swift
+++ b/Tests/Enterprise/Financial/FinancialTests.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 import XCTest
 import Combine
 
@@ -963,3 +964,4 @@ final class FinancialIntegrationTests: XCTestCase {
         )
     }
 }
+#endif

--- a/Tests/Integration/IntegrationTests.swift
+++ b/Tests/Integration/IntegrationTests.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 //
 //  IntegrationTests.swift
 //  DiamondDeskERPTests
@@ -566,3 +567,4 @@ struct IntegrationTests {
         await taskViewModel1.deleteTask(testTask.id.recordName)
     }
 }
+#endif

--- a/Tests/Performance/ComplexWorkflowPerformanceBenchmarks.swift
+++ b/Tests/Performance/ComplexWorkflowPerformanceBenchmarks.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 import Foundation
 import CloudKit
 import XCTest
@@ -710,3 +711,4 @@ struct SyncConflict {
 }
 
 // Additional workflow classes would be implemented similarly...
+#endif

--- a/Tests/Performance/PerformanceBaseline.swift
+++ b/Tests/Performance/PerformanceBaseline.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 import Foundation
 import XCTest
 
@@ -299,3 +300,4 @@ class PerformanceBaseline: XCTestCase {
         return documentsPath.appendingPathComponent(baselineFile)
     }
 }
+#endif

--- a/Tests/Performance/PerformanceRegressionTests.swift
+++ b/Tests/Performance/PerformanceRegressionTests.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 import Foundation
 import XCTest
 
@@ -314,3 +315,4 @@ class PerformanceRegressionTests: XCTestCase {
         return documentsPath.appendingPathComponent("PerformanceReports")
     }
 }
+#endif

--- a/Tests/Performance/UIPerformanceTests.swift
+++ b/Tests/Performance/UIPerformanceTests.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 import SwiftUI
 import XCTest
 
@@ -500,3 +501,4 @@ extension XCTestCase {
         return result
     }
 }
+#endif

--- a/Tests/Security/SecurityAuditTests.swift
+++ b/Tests/Security/SecurityAuditTests.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 import CryptoKit
 import LocalAuthentication
 import XCTest
@@ -676,3 +677,4 @@ enum RiskLevel {
     case high
     case critical
 }
+#endif

--- a/Tests/UI/DiamondDeskERPUITests.swift
+++ b/Tests/UI/DiamondDeskERPUITests.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 //
 //  DiamondDeskERPUITests.swift
 //  DiamondDeskERPUITests
@@ -39,3 +40,4 @@ final class DiamondDeskERPUITests: XCTestCase {
         }
     }
 }
+#endif

--- a/Tests/Unit/AuditRepositoryTests.swift
+++ b/Tests/Unit/AuditRepositoryTests.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 //
 //  AuditRepositoryTests.swift
 //  DiamondDeskERPTests
@@ -463,3 +464,4 @@ struct AuditRepositoryTests {
         }
     }
 }
+#endif

--- a/Tests/Unit/AuditViewModelTests.swift
+++ b/Tests/Unit/AuditViewModelTests.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 //
 //  AuditViewModelTests.swift
 //  DiamondDeskERPTests
@@ -573,3 +574,4 @@ struct AuditViewModelTests {
         #expect(viewModel.audits.isEmpty)
     }
 }
+#endif

--- a/Tests/Unit/ClientViewModelTests.swift
+++ b/Tests/Unit/ClientViewModelTests.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 //
 //  ClientViewModelTests.swift
 //  DiamondDeskERPTests
@@ -551,3 +552,4 @@ struct ClientViewModelTests {
         #expect(viewModel.error == nil)
     }
 }
+#endif

--- a/Tests/Unit/DiamondDeskERPTests.swift
+++ b/Tests/Unit/DiamondDeskERPTests.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 //
 //  DiamondDeskERPTests.swift
 //  DiamondDeskERPTests
@@ -390,3 +391,4 @@ struct TaskViewModelTests {
         #expect(viewModel.error == nil)
     }
 }
+#endif

--- a/Tests/Unit/DirectoryViewModelTests.swift
+++ b/Tests/Unit/DirectoryViewModelTests.swift
@@ -1,1 +1,3 @@
+#if canImport(XCTest)
 
+#endif

--- a/Tests/Unit/DocumentViewModelTests.swift
+++ b/Tests/Unit/DocumentViewModelTests.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 import XCTest
 
 @MainActor
@@ -61,3 +62,4 @@ class DocumentViewModelTests: XCTestCase {
     }
 }
 
+#endif

--- a/Tests/Unit/Enterprise/AssetManagement/AssetManagementServiceTests.swift
+++ b/Tests/Unit/Enterprise/AssetManagement/AssetManagementServiceTests.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 import CloudKit
 import XCTest
 
@@ -432,3 +433,4 @@ final class AssetCloudKitTests: XCTestCase {
         XCTAssertEqual(deserializedLog?.sessionId, usageLog.sessionId)
     }
 }
+#endif

--- a/Tests/Unit/Enterprise/Employee/EmployeeServiceTests.swift
+++ b/Tests/Unit/Enterprise/Employee/EmployeeServiceTests.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 import CloudKit
 import XCTest
 
@@ -558,3 +559,4 @@ final class EmployeeCloudKitTests: XCTestCase {
         XCTAssertEqual(deserializedReview?.notes, review.notes)
     }
 }
+#endif

--- a/Tests/Unit/Enterprise/PermissionsTests.swift
+++ b/Tests/Unit/Enterprise/PermissionsTests.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 //
 //  PermissionsTests.swift
 //  DiamondDeskERPTests
@@ -579,3 +580,4 @@ extension UnifiedPermissionsService {
         }
     }
 }
+#endif

--- a/Tests/Unit/Enterprise/UnifiedPermissionsServiceTests.swift
+++ b/Tests/Unit/Enterprise/UnifiedPermissionsServiceTests.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 //
 //  UnifiedPermissionsServiceTests.swift
 //  DiamondDeskERPTests
@@ -625,3 +626,4 @@ struct ResolvedPermissions {
     let resolvedAt: Date
     let cacheExpiry: Date
 }
+#endif

--- a/Tests/Unit/Enterprise/Workflow/WorkflowServiceTests.swift
+++ b/Tests/Unit/Enterprise/Workflow/WorkflowServiceTests.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 import CloudKit
 import XCTest
 
@@ -342,3 +343,4 @@ final class WorkflowCloudKitTests: XCTestCase {
         XCTAssertEqual(deserializedExecution?.triggerMethod, execution.triggerMethod)
     }
 }
+#endif

--- a/Tests/Unit/ModelTests.swift
+++ b/Tests/Unit/ModelTests.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 //
 //  ModelTests.swift
 //  DiamondDeskERPTests
@@ -518,3 +519,4 @@ struct ModelTests {
         #expect(ticket.assignedToUserRef?.recordID.recordName == "assigned-user")
     }
 }
+#endif

--- a/Tests/Unit/NewModelsTests.swift
+++ b/Tests/Unit/NewModelsTests.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 import XCTest
 @testable import DiamondDeskERP
 
@@ -298,3 +299,4 @@ extension NewModelsTests {
         }
     }
 }
+#endif

--- a/Tests/Unit/PerformanceRepositoryTests.swift
+++ b/Tests/Unit/PerformanceRepositoryTests.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 //
 //  PerformanceRepositoryTests.swift
 //  DiamondDeskERPTests
@@ -582,3 +583,4 @@ struct PerformanceRepositoryTests {
         }
     }
 }
+#endif

--- a/Tests/Unit/PerformanceTargetsViewModelTests.swift
+++ b/Tests/Unit/PerformanceTargetsViewModelTests.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 import DiamondDeskERP
 import XCTest
 
@@ -44,3 +45,4 @@ class PerformanceTargetsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.errorMessage, "Fetch error")
     }
 }
+#endif

--- a/Tests/Unit/PerformanceViewModelTests.swift
+++ b/Tests/Unit/PerformanceViewModelTests.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 //
 //  PerformanceViewModelTests.swift
 //  DiamondDeskERPTests
@@ -689,3 +690,4 @@ struct PerformanceViewModelTests {
         #expect(viewModel.targets.isEmpty)
     }
 }
+#endif

--- a/Tests/Unit/ProjectListViewModelTests.swift
+++ b/Tests/Unit/ProjectListViewModelTests.swift
@@ -1,1 +1,3 @@
+#if canImport(XCTest)
 
+#endif

--- a/Tests/Unit/ProjectModelTests.swift
+++ b/Tests/Unit/ProjectModelTests.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 import CloudKit
 import XCTest
 
@@ -754,3 +755,4 @@ extension ProjectModelTests {
         return project
     }
 }
+#endif

--- a/Tests/Unit/ProjectPortfolioServiceTests.swift
+++ b/Tests/Unit/ProjectPortfolioServiceTests.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 import CloudKit
 import XCTest
 
@@ -850,3 +851,4 @@ extension ProjectPortfolioServiceTests {
         XCTAssertGreaterThanOrEqual(portfolioService.projects.count, 2)
     }
 }
+#endif

--- a/Tests/Unit/RepositoryTests.swift
+++ b/Tests/Unit/RepositoryTests.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 //
 //  RepositoryTests.swift
 //  DiamondDeskERPTests
@@ -492,3 +493,4 @@ struct RepositoryTests {
         }
     }
 }
+#endif

--- a/Tests/Unit/RoleHierarchyTests.swift
+++ b/Tests/Unit/RoleHierarchyTests.swift
@@ -1,1 +1,3 @@
+#if canImport(XCTest)
 
+#endif

--- a/Tests/Unit/SeederTests.swift
+++ b/Tests/Unit/SeederTests.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 import CloudKit
 import XCTest
 
@@ -46,3 +47,4 @@ class MockCKDatabase: CKDatabase {
         return record
     }
 }
+#endif

--- a/Tests/Unit/SequenceUniqueTests.swift
+++ b/Tests/Unit/SequenceUniqueTests.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 import XCTest
 @testable import DiamondDeskERP
 
@@ -20,3 +21,4 @@ class SequenceUniqueTests: XCTestCase {
         XCTAssertEqual(unique, ["a", "b", "c"])
     }
 }
+#endif

--- a/Tests/Unit/ServiceTests.swift
+++ b/Tests/Unit/ServiceTests.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 //
 //  ServiceTests.swift
 //  DiamondDeskERPTests
@@ -397,3 +398,4 @@ import UserNotifications
     }
 }
 
+#endif

--- a/Tests/Unit/Services/AnalyticsConsentServiceTests.swift
+++ b/Tests/Unit/Services/AnalyticsConsentServiceTests.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 import XCTest
 @testable import DiamondDeskERP
 
@@ -489,3 +490,4 @@ final class ConsentStatusTests: XCTestCase {
         }
     }
 }
+#endif

--- a/Tests/Unit/TicketViewModelTests.swift
+++ b/Tests/Unit/TicketViewModelTests.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 //
 //  TicketViewModelTests.swift
 //  DiamondDeskERPTests
@@ -526,3 +527,4 @@ struct TicketViewModelTests {
         #expect(abs(avgTime - 5400) < 60) // Average of 1.5 hours (5400 seconds), allowing small variance
     }
 }
+#endif

--- a/Tests/Unit/VendorLifecycleTests.swift
+++ b/Tests/Unit/VendorLifecycleTests.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 import XCTest
 @testable import DiamondDeskERP
 
@@ -619,3 +620,4 @@ extension VendorLifecycleService {
         self.vendors = vendors
     }
 }
+#endif


### PR DESCRIPTION
## Summary
- wrap all Swift test files in `#if canImport(XCTest)` guards

These guards ensure the test sources are ignored when XCTest is unavailable, preventing build errors when compiling the main target.

## Testing
- `swiftc -parse Tests/Unit/ServiceTests.swift`


------
https://chatgpt.com/codex/tasks/task_b_687e783e10e0832eaaa57ccdb0a33f58