### PR TITLE
Add missing PT3VS1 domain models

### DIFF
--- a/Sources/Domain/AuditTemplate.swift
+++ b/Sources/Domain/AuditTemplate.swift
@@ -648,3 +648,6 @@ public struct AuditTemplate: Identifiable, Codable {
         )
     }
 }
+
+public typealias AuditItem = AuditQuestion
+

--- a/Sources/Domain/CustomReports.swift
+++ b/Sources/Domain/CustomReports.swift
@@ -606,3 +606,90 @@ extension CustomReportModel {
         )
     }
 }
+
+// MARK: - Upload Record
+public struct UploadRecord: Identifiable, Codable, Hashable {
+    public let id: String
+    public var reportId: String
+    public var filename: String
+    public var version: Int
+    public var uploadDate: Date
+    public var fileSize: Int
+    public var processedRows: Int?
+    public var errorCount: Int?
+    public init(id: String = UUID().uuidString, reportId: String, filename: String, version: Int = 1, uploadDate: Date = Date(), fileSize: Int = 0, processedRows: Int? = nil, errorCount: Int? = nil) {
+        self.id = id
+        self.reportId = reportId
+        self.filename = filename
+        self.version = version
+        self.uploadDate = uploadDate
+        self.fileSize = fileSize
+        self.processedRows = processedRows
+        self.errorCount = errorCount
+    }
+}
+
+// MARK: - Report Log
+public struct ReportLog: Identifiable, Codable, Hashable {
+    public let id: String
+    public var reportId: String
+    public var entryDate: Date
+    public var summary: String
+    public var executionTime: Double?
+    public var status: String
+    public var errorDetails: String?
+    public init(id: String = UUID().uuidString, reportId: String, entryDate: Date = Date(), summary: String, executionTime: Double? = nil, status: String = "SUCCESS", errorDetails: String? = nil) {
+        self.id = id
+        self.reportId = reportId
+        self.entryDate = entryDate
+        self.summary = summary
+        self.executionTime = executionTime
+        self.status = status
+        self.errorDetails = errorDetails
+    }
+}
+
+extension UploadRecord {
+    public func toRecord() -> CKRecord {
+        let record = CKRecord(recordType: "UploadRecord", recordID: CKRecord.ID(recordName: id))
+        record["reportId"] = reportId
+        record["filename"] = filename
+        record["version"] = version as NSNumber
+        record["uploadDate"] = uploadDate
+        record["fileSize"] = fileSize as NSNumber
+        record["processedRows"] = processedRows as NSNumber?
+        record["errorCount"] = errorCount as NSNumber?
+        return record
+    }
+    public static func from(record: CKRecord) -> UploadRecord? {
+        guard let reportId = record["reportId"] as? String,
+              let filename = record["filename"] as? String,
+              let version = record["version"] as? Int,
+              let uploadDate = record["uploadDate"] as? Date,
+              let fileSize = record["fileSize"] as? Int else { return nil }
+        let processedRows = record["processedRows"] as? Int
+        let errorCount = record["errorCount"] as? Int
+        return UploadRecord(id: record.recordID.recordName, reportId: reportId, filename: filename, version: version, uploadDate: uploadDate, fileSize: fileSize, processedRows: processedRows, errorCount: errorCount)
+    }
+}
+extension ReportLog {
+    public func toRecord() -> CKRecord {
+        let record = CKRecord(recordType: "ReportLog", recordID: CKRecord.ID(recordName: id))
+        record["reportId"] = reportId
+        record["entryDate"] = entryDate
+        record["summary"] = summary
+        if let executionTime = executionTime { record["executionTime"] = executionTime as NSNumber }
+        record["status"] = status
+        record["errorDetails"] = errorDetails
+        return record
+    }
+    public static func from(record: CKRecord) -> ReportLog? {
+        guard let reportId = record["reportId"] as? String,
+              let entryDate = record["entryDate"] as? Date,
+              let summary = record["summary"] as? String,
+              let status = record["status"] as? String else { return nil }
+        let executionTime = record["executionTime"] as? Double
+        let errorDetails = record["errorDetails"] as? String
+        return ReportLog(id: record.recordID.recordName, reportId: reportId, entryDate: entryDate, summary: summary, executionTime: executionTime, status: status, errorDetails: errorDetails)
+    }
+}

--- a/Sources/Domain/Dashboard.swift
+++ b/Sources/Domain/Dashboard.swift
@@ -602,3 +602,7 @@ extension DashboardModel {
         )
     }
 }
+
+public typealias WidgetConfig = WidgetConfiguration
+
+public typealias UserDashboard = DashboardModel

--- a/Sources/Domain/Office365Integration.swift
+++ b/Sources/Domain/Office365Integration.swift
@@ -642,3 +642,45 @@ extension Office365IntegrationModel {
         )
     }
 }
+
+// MARK: - Microsoft Graph Sync
+public struct MicrosoftGraphSync: Identifiable, Codable, Hashable {
+    public let id: String
+    public var userId: String
+    public var resourceType: String
+    public var lastSyncToken: String?
+    public var syncStatus: String
+    public var errorCount: Int
+    public init(id: String = UUID().uuidString, userId: String, resourceType: String, lastSyncToken: String? = nil, syncStatus: String = "PENDING", errorCount: Int = 0) {
+        self.id = id
+        self.userId = userId
+        self.resourceType = resourceType
+        self.lastSyncToken = lastSyncToken
+        self.syncStatus = syncStatus
+        self.errorCount = errorCount
+    }
+}
+extension MicrosoftGraphSync {
+    public func toRecord() -> CKRecord {
+        let record = CKRecord(recordType: "MicrosoftGraphSync", recordID: CKRecord.ID(recordName: id))
+        record["userId"] = userId
+        record["resourceType"] = resourceType
+        record["lastSyncToken"] = lastSyncToken
+        record["syncStatus"] = syncStatus
+        record["errorCount"] = errorCount as NSNumber
+        return record
+    }
+    public static func from(record: CKRecord) -> MicrosoftGraphSync? {
+        guard let userId = record["userId"] as? String,
+              let resourceType = record["resourceType"] as? String,
+              let syncStatus = record["syncStatus"] as? String,
+              let errorCount = record["errorCount"] as? Int else { return nil }
+        let lastSyncToken = record["lastSyncToken"] as? String
+        return MicrosoftGraphSync(id: record.recordID.recordName,
+                                  userId: userId,
+                                  resourceType: resourceType,
+                                  lastSyncToken: lastSyncToken,
+                                  syncStatus: syncStatus,
+                                  errorCount: errorCount)
+    }
+}


### PR DESCRIPTION
## Summary
- implement `UploadRecord` and `ReportLog` models
- add CloudKit support for both new models
- implement `MicrosoftGraphSync` model with CloudKit helpers
- provide PT3VS1 naming aliases for `AuditItem`, `WidgetConfig`, and `UserDashboard`

## Testing
- `swiftc -typecheck Sources/Domain/CustomReports.swift` *(fails: no such module 'CloudKit')*


------
https://chatgpt.com/codex/tasks/task_b_687e878307f0832eb71ef3feced5d468